### PR TITLE
Trocando nós "legado" de transacao para desconto, peso e frete (conforme documentação no Akatus Connect)

### DIFF
--- a/Akatus.Src/Carrinho/Carrinho.cs
+++ b/Akatus.Src/Carrinho/Carrinho.cs
@@ -404,14 +404,14 @@ namespace Akatus.Carrinho
                                 {
                                     #region Boleto ou Cartão de Débito
 
-                                    //Adiciona elemento 'desconto_total'
-                                    writer.WriteElementString("desconto_total", Akatus.Util.formatCurrency(this.Transacao.DescontoTotal));
+                                    //Adiciona elemento 'desconto'
+                                    writer.WriteElementString("desconto", Akatus.Util.formatCurrency(this.Transacao.Desconto));
 
-                                    //Adiciona elemento 'peso_total'
-                                    writer.WriteElementString("peso_total", Akatus.Util.formatCurrency(this.Transacao.PesoTotal));
+                                    //Adiciona elemento 'peso'
+                                    writer.WriteElementString("peso", Akatus.Util.formatCurrency(this.Transacao.Peso));
 
-                                    //Adiciona elemento 'frete_total'
-                                    writer.WriteElementString("frete_total", Akatus.Util.formatCurrency(this.Transacao.FreteTotal));
+                                    //Adiciona elemento 'frete'
+                                    writer.WriteElementString("frete", Akatus.Util.formatCurrency(this.Transacao.Frete));
 
                                     //Adiciona elemento 'moeda' (O único valor aceito hoje é BRL)
                                     writer.WriteElementString("moeda", this.Transacao.Moeda);
@@ -444,14 +444,14 @@ namespace Akatus.Carrinho
                                     //Adiciona elemento 'expiracao'
                                     writer.WriteElementString("expiracao", this.Transacao.Cartao.Expiracao);
 
-                                    //Adiciona elemento 'desconto_total'
-                                    writer.WriteElementString("desconto_total", Akatus.Util.formatCurrency(this.Transacao.DescontoTotal));
+                                    //Adiciona elemento 'desconto'
+                                    writer.WriteElementString("desconto", Akatus.Util.formatCurrency(this.Transacao.Desconto));
 
-                                    //Adiciona elemento 'peso_total'
-                                    writer.WriteElementString("peso_total", Akatus.Util.formatCurrency(this.Transacao.PesoTotal));
+                                    //Adiciona elemento 'peso'
+                                    writer.WriteElementString("peso", Akatus.Util.formatCurrency(this.Transacao.Peso));
 
-                                    //Adiciona elemento 'frete_total'
-                                    writer.WriteElementString("frete_total", Akatus.Util.formatCurrency(this.Transacao.FreteTotal));
+                                    //Adiciona elemento 'frete'
+                                    writer.WriteElementString("frete", Akatus.Util.formatCurrency(this.Transacao.Frete));
 
                                     //Adiciona elemento 'moeda' (O único valor aceito hoje é BRL)
                                     writer.WriteElementString("moeda", this.Transacao.Moeda);

--- a/Akatus.Src/Carrinho/Transacao.cs
+++ b/Akatus.Src/Carrinho/Transacao.cs
@@ -18,9 +18,9 @@ namespace Akatus.Carrinho
     {
         #region Fields
 
-        private decimal _desconto_total;
-        private decimal _peso_total;
-        private decimal _frete_total;
+        private decimal _desconto;
+        private decimal _peso;
+        private decimal _frete;
         private string _moeda;
         private string _referencia;
         private Akatus.Enums.MeioDePagamento _meioDePagamento;
@@ -31,47 +31,47 @@ namespace Akatus.Carrinho
         #region Properties
 
         /// <summary>
-        /// Soma de todos os descontos de todos os produtos
+        /// Desconto dado para toda a transação (ao invés de desconto por produto)
         /// </summary>
-        public decimal DescontoTotal
+        public decimal Desconto
         {
             get
             {
-                return _desconto_total;
+                return _desconto;
             }
             set
             {
-                _desconto_total = value;
+                _desconto = value;
             }
         }
 
         /// <summary>
-        /// Soma do peso de todos os produtos
+        /// Peso geral para toda a transação (ao invés de peso específico por produto)
         /// </summary>
-        public decimal PesoTotal
+        public decimal Peso
         {
             get
             {
-                return _peso_total;
+                return _peso;
             }
             set
             {
-                _peso_total = value;
+                _peso = value;
             }
         }
 
         /// <summary>
-        /// Soma do valor de todos os fretes dos produtos
+        /// Frete para toda a transação (ao invés de ser específico por produto)
         /// </summary>
-        public decimal FreteTotal
+        public decimal Frete
         {
             get
             {
-                return _frete_total;
+                return _frete;
             }
             set
             {
-                _frete_total = value;
+                _frete = value;
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ carrinho.Produtos.Add(produto);
 
 //Forma de Pagamento (Boleto)
 //carrinho.Transacao.MeioDePagamento = Akatus.Enums.MeioDePagamento.boleto;
-//carrinho.Transacao.DescontoTotal = 0;
-//carrinho.Transacao.PesoTotal = 0;
-//carrinho.Transacao.FreteTotal = 0;
+//carrinho.Transacao.Desconto = 0;
+//carrinho.Transacao.Peso = 0;
+//carrinho.Transacao.Frete = 0;
 //carrinho.Transacao.Moeda = "BRL";
 //carrinho.Transacao.Referencia = "OFP12345";
 
@@ -86,9 +86,9 @@ carrinho.Transacao.Cartao.Portador.Nome = "AUTORIZAR";
 carrinho.Transacao.Cartao.Portador.CPF = "721.726.663-78";
 carrinho.Transacao.Cartao.Portador.Portador.Telefone = "7199990000";
 
-carrinho.Transacao.DescontoTotal = 0;
-carrinho.Transacao.PesoTotal = 0;
-carrinho.Transacao.FreteTotal = 0;
+carrinho.Transacao.Desconto = 0;
+carrinho.Transacao.Peso = 0;
+carrinho.Transacao.Frete = 0;
 carrinho.Transacao.Moeda = "BRL";
 
 //Envia carrinho


### PR DESCRIPTION
Como pode verificar na documentação do Akatus Connect, não existem mais os nós desconto_total, peso_total e frete_total.

Peço também que gere novamente as DLLs, pois elas contém os valores antigos. Eu só não gerei porque não utilizo Windows.

Obrigado.
